### PR TITLE
Remove email button, mobile-only call/text, AI draft in compose

### DIFF
--- a/src/app/(dashboard)/contacts/[id]/page.tsx
+++ b/src/app/(dashboard)/contacts/[id]/page.tsx
@@ -7,7 +7,6 @@ import AddActivityForm from '@/components/add-activity-form'
 import AddTaskForm from '@/components/add-task-form'
 import KeyNotes from '@/components/key-notes'
 import { ClickToCall, ClickToEmail, ClickToText } from '@/components/click-actions'
-import CopyEmailButton from '@/components/copy-email-button'
 import AiDraft from '@/components/ai-draft'
 import MeetingPrep from '@/components/ai-meeting-prep'
 import NoteProcessor from '@/components/ai-note-processor'
@@ -151,23 +150,20 @@ export default async function ContactDetailPage({ params }: { params: Promise<{ 
         </div>
       </div>
 
-      {/* Quick action bar — one-tap call, email, text */}
+      {/* Quick action bar — one-tap call, text (mobile/app only), LinkedIn always visible */}
       <div className="flex flex-wrap gap-2 mb-6">
         {contact.mobile_phone && (
-          <a href={`tel:${contact.mobile_phone}`} className="flex items-center gap-1.5 px-4 py-2.5 bg-green-600 text-white rounded-lg text-sm font-semibold active:scale-95 transition-all">
+          <a href={`tel:${contact.mobile_phone}`} className="flex md:hidden items-center gap-1.5 px-4 py-2.5 bg-green-600 text-white rounded-lg text-sm font-semibold active:scale-95 transition-all">
             📱 Call Mobile
           </a>
         )}
         {contact.phone && (
-          <a href={`tel:${contact.phone}`} className="flex items-center gap-1.5 px-4 py-2.5 bg-green-600 text-white rounded-lg text-sm font-semibold active:scale-95 transition-all">
+          <a href={`tel:${contact.phone}`} className="flex md:hidden items-center gap-1.5 px-4 py-2.5 bg-green-600 text-white rounded-lg text-sm font-semibold active:scale-95 transition-all">
             📞 Call Office
           </a>
         )}
-        {contact.email && (
-          <CopyEmailButton email={contact.email} />
-        )}
         {contact.mobile_phone && (
-          <a href={`sms:${contact.mobile_phone}`} className="flex items-center gap-1.5 px-4 py-2.5 bg-purple-600 text-white rounded-lg text-sm font-semibold active:scale-95 transition-all">
+          <a href={`sms:${contact.mobile_phone}`} className="flex md:hidden items-center gap-1.5 px-4 py-2.5 bg-purple-600 text-white rounded-lg text-sm font-semibold active:scale-95 transition-all">
             💬 Text
           </a>
         )}
@@ -218,7 +214,7 @@ export default async function ContactDetailPage({ params }: { params: Promise<{ 
                 <div>
                   <span className="text-one70-mid">Office:</span>
                   <span className="ml-1 text-one70-dark">{contact.phone}</span>
-                  <div className="flex items-center gap-1 mt-0.5">
+                  <div className="flex md:hidden items-center gap-1 mt-0.5">
                     <ClickToCall value={contact.phone} contactId={id} orgId={contact.org_id} contactName={contactName} />
                     <ClickToText value={contact.phone} contactId={id} orgId={contact.org_id} contactName={contactName} />
                   </div>
@@ -228,7 +224,7 @@ export default async function ContactDetailPage({ params }: { params: Promise<{ 
                 <div>
                   <span className="text-one70-mid">Mobile:</span>
                   <span className="ml-1 text-one70-dark">{contact.mobile_phone}</span>
-                  <div className="flex items-center gap-1 mt-0.5">
+                  <div className="flex md:hidden items-center gap-1 mt-0.5">
                     <ClickToCall value={contact.mobile_phone} contactId={id} orgId={contact.org_id} contactName={contactName} />
                     <ClickToText value={contact.mobile_phone} contactId={id} orgId={contact.org_id} contactName={contactName} />
                   </div>

--- a/src/app/(dashboard)/organizations/[id]/page.tsx
+++ b/src/app/(dashboard)/organizations/[id]/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { ArrowLeft, Pencil, Building2, Users, MapPin, Phone, Globe, Activity } from 'lucide-react'
 import AddActivityForm from '@/components/add-activity-form'
 import AddTaskForm from '@/components/add-task-form'
-import { ClickToCall, ClickToEmail, ClickToText } from '@/components/click-actions'
+import { ClickToCall, ClickToText } from '@/components/click-actions'
 import AiDraft from '@/components/ai-draft'
 import MeetingPrep from '@/components/ai-meeting-prep'
 import NoteProcessor from '@/components/ai-note-processor'
@@ -135,10 +135,9 @@ export default async function OrganizationDetailPage({ params }: { params: Promi
                         <p className="text-xs text-one70-mid">{c.title}</p>
                       </Link>
                     </div>
-                    <div className="flex flex-wrap gap-2 mt-2">
+                    <div className="flex md:hidden flex-wrap gap-2 mt-2">
                       {c.phone && <ClickToCall value={c.phone} contactId={c.id} orgId={id} contactName={`${c.first_name} ${c.last_name}`} />}
                       {c.phone && <ClickToText value={c.phone} contactId={c.id} orgId={id} contactName={`${c.first_name} ${c.last_name}`} />}
-                      {c.email && <ClickToEmail value={c.email} contactId={c.id} orgId={id} contactName={`${c.first_name} ${c.last_name}`} />}
                     </div>
                   </div>
                 ))}

--- a/src/components/compose-email.tsx
+++ b/src/components/compose-email.tsx
@@ -1,8 +1,17 @@
 'use client'
 
 import { useState } from 'react'
-import { Send, X, Loader2, ChevronDown, ChevronUp, Paperclip, CheckCircle, Sparkles } from 'lucide-react'
+import { Send, X, Loader2, ChevronDown, ChevronUp, Paperclip, CheckCircle, Sparkles, RefreshCw } from 'lucide-react'
 import RecipientInput from '@/components/recipient-input'
+
+const AI_SEQUENCE_STEPS = [
+  { id: 'cold', label: 'Cold Open' },
+  { id: 'followUp1', label: 'Follow-up 1' },
+  { id: 'followUp2', label: 'Follow-up 2' },
+  { id: 'breakup', label: 'Break-up' },
+  { id: 'post_meeting', label: 'Post-Meeting' },
+  { id: 'referral', label: 'Referral Intro' },
+]
 
 interface Props {
   defaultTo?: string
@@ -25,7 +34,40 @@ export default function ComposeEmail({ defaultTo, defaultSubject, contactId, org
   const [sending, setSending] = useState(false)
   const [sent, setSent] = useState(false)
   const [error, setError] = useState('')
-  const [drafting, setDrafting] = useState(false)
+  const [aiOpen, setAiOpen] = useState(false)
+  const [aiLoading, setAiLoading] = useState(false)
+  const [aiStep, setAiStep] = useState('cold')
+  const [aiError, setAiError] = useState('')
+
+  async function handleAiDraft() {
+    setAiLoading(true)
+    setAiError('')
+
+    const res = await fetch('/api/ai/draft-message', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contactId, orgId, dealId, channel: 'email', sequenceStep: aiStep }),
+    })
+
+    const data = await res.json()
+    setAiLoading(false)
+
+    if (!res.ok || !data.success) {
+      setAiError(data.error || 'Failed to generate draft')
+      return
+    }
+
+    // Parse subject line from AI response (format: "Subject: ...\n\n...")
+    const msg = data.message || ''
+    const subjectMatch = msg.match(/^(?:Subject:\s*)(.+)/i)
+    if (subjectMatch) {
+      setSubject(subjectMatch[1].trim())
+      const bodyStart = msg.indexOf('\n', subjectMatch.index! + subjectMatch[0].length)
+      setBody(msg.slice(bodyStart).replace(/^\n+/, ''))
+    } else {
+      setBody(msg)
+    }
+  }
 
   async function handleSend() {
     if (!to.trim() || !subject.trim()) { setError('Recipient and subject are required'); return }
@@ -113,6 +155,35 @@ export default function ComposeEmail({ defaultTo, defaultSubject, contactId, org
             <input type="text" value={subject} onChange={e => setSubject(e.target.value)}
               placeholder="Subject"
               className="flex-1 text-sm border border-one70-border rounded px-2.5 py-1.5 focus:outline-none focus:border-blue-500" />
+          </div>
+
+          {/* AI Draft toolbar */}
+          <div className="border border-amber-200 rounded-md overflow-hidden">
+            <button onClick={() => setAiOpen(!aiOpen)}
+              className="flex items-center gap-1.5 w-full px-2.5 py-1.5 text-xs font-medium bg-amber-50 text-amber-800 hover:bg-amber-100 transition-colors">
+              <Sparkles size={12} />
+              AI Draft
+              {aiOpen ? <ChevronUp size={12} className="ml-auto" /> : <ChevronDown size={12} className="ml-auto" />}
+            </button>
+            {aiOpen && (
+              <div className="px-2.5 py-2 bg-amber-50/50 space-y-2">
+                <div className="flex flex-wrap gap-1">
+                  {AI_SEQUENCE_STEPS.map(s => (
+                    <button key={s.id} onClick={() => setAiStep(s.id)}
+                      className={`px-2 py-1 rounded-full text-[11px] font-medium transition-colors ${
+                        aiStep === s.id ? 'bg-amber-600 text-white' : 'bg-white border border-gray-200 text-gray-600 hover:bg-gray-50'
+                      }`}>
+                      {s.label}
+                    </button>
+                  ))}
+                </div>
+                <button onClick={handleAiDraft} disabled={aiLoading}
+                  className="flex items-center gap-1.5 px-3 py-1.5 bg-one70-black text-white rounded text-xs font-semibold hover:bg-one70-dark disabled:opacity-50 transition-colors">
+                  {aiLoading ? <><RefreshCw size={12} className="animate-spin" /> Generating...</> : <><Sparkles size={12} /> Generate Draft</>}
+                </button>
+                {aiError && <p className="text-xs text-red-600">{aiError}</p>}
+              </div>
+            )}
           </div>
 
           <textarea value={body} onChange={e => setBody(e.target.value)}


### PR DESCRIPTION
## Summary
- Removed big Copy Email button from contact detail quick action bar
- Made Call Mobile, Call Office, and Text buttons mobile-only (hidden on desktop)
- Made ClickToCall/ClickToText mobile-only in contact info section and organization contacts list
- Integrated AI Draft tool into ComposeEmail component with sequence step picker

## Test plan
- [ ] Verify Copy Email button no longer appears on contact page
- [ ] Verify call/text buttons only show on mobile screen sizes
- [ ] Verify AI Draft toolbar works inside email compose form

https://claude.ai/code/session_015Qxpa8nzDSH4AK2Tn2KvuG