### PR TITLE
Fix floating add-project button

### DIFF
--- a/public/tools/weekly-update.html
+++ b/public/tools/weekly-update.html
@@ -14,9 +14,9 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Arial,sans-serif;ba
 /* ---- sidebar (projects + history) ---- */
 .sidebar{background:#fff;border-radius:10px;border:1px solid #DDD9D0;padding:16px;position:sticky;top:20px}
 .sidebar h3{font-size:10px;text-transform:uppercase;letter-spacing:.08em;color:#999;margin-bottom:8px;font-weight:700}
-.proj-select-wrap{display:flex;gap:6px;margin-bottom:6px}
-.proj-select{flex:1;padding:8px 10px;border:1px solid #DDD9D0;border-radius:6px;font-size:13px;font-family:inherit;background:#fff;color:#1A1A1A}
-.icon-btn{width:34px;height:34px;flex-shrink:0;border:1px solid #DDD9D0;background:#F7F6F2;border-radius:6px;cursor:pointer;font-size:16px;color:#555;display:flex;align-items:center;justify-content:center;transition:all .15s}
+.proj-select-wrap{display:flex;align-items:center;gap:6px;margin-bottom:6px}
+.proj-select{flex:1;height:34px;padding:0 10px;border:1px solid #DDD9D0;border-radius:6px;font-size:13px;font-family:inherit;background:#fff;color:#1A1A1A;box-sizing:border-box}
+.icon-btn{width:34px;height:34px;flex-shrink:0;border:1px solid #DDD9D0;background:#F7F6F2;border-radius:6px;cursor:pointer;font-size:16px;color:#555;display:flex;align-items:center;justify-content:center;transition:all .15s;box-sizing:border-box}
 .icon-btn:hover{border-color:#F5C518;color:#1A1A1A}
 .new-proj-row{display:none;gap:6px;margin-top:8px}
 .new-proj-row.show{display:flex}


### PR DESCRIPTION
## Summary

Small follow-up to #16 — the `+` add-project button next to the project dropdown looked visually detached/floating (screenshot from the deployed tool). Root cause: `.proj-select` had no explicit height, so its rendered height depends on browser default `<select>` sizing and could drift from the adjacent `.icon-btn`'s fixed 34px. Gave both an explicit matching height + `box-sizing: border-box`, and centered them in the flex row.

Also cleaned up 4 leftover test projects (`AUTOSAVE_TEST ...`, `DEBUG2_TEST ...`, `Test Project`) that were visible in the live `wu_projects` table — leaked from earlier test runs in this session that crashed before reaching their cleanup step. One of them (`AUTOSAVE_TEST 1782954155956`) is the project visible in the reported screenshot. Left the real "7 New Lake" project untouched.

CSS-only change, no JS/behavior touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PfHJJcPBPACD6iRCxbJAF2)_