### PR TITLE
Make the ONE70 header persistent across all states

### DIFF
--- a/public/tools/weekly-update.html
+++ b/public/tools/weekly-update.html
@@ -51,7 +51,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Arial,sans-serif;ba
 .page{background:#fff;border-radius:10px;border:1px solid #DDD9D0;overflow:hidden}
 .page.disabled{opacity:.45;pointer-events:none}
 
-.header{background:#1A1A1A;padding:10px 20px;display:flex;align-items:center;justify-content:space-between;gap:12px}
+.header{background:#1A1A1A;padding:10px 20px;display:flex;align-items:center;justify-content:space-between;gap:12px;border-radius:10px;margin-bottom:20px}
 .header-logo{height:50px;width:auto;display:block;flex-shrink:0}
 .header-center{text-align:center;flex:1}
 .doc-title{color:#fff;font-size:16px;font-weight:700;letter-spacing:.06em}
@@ -198,6 +198,15 @@ input[type="date"]::-webkit-calendar-picker-indicator{opacity:0.4;cursor:pointer
   <!-- ============ MAIN: form or empty state ============ -->
   <div id="mainArea">
 
+  <div class="header">
+    <img class="header-logo" src="/logo-300.jpg" alt="ONE70 Group">
+    <div class="header-center"><div class="doc-title">WEEKLY PROJECT UPDATE</div></div>
+    <div class="header-right">
+      <span class="upd-lbl">UPDATE #</span>
+      <span class="upd-value" id="updateNumDisplay">—</span>
+    </div>
+  </div>
+
   <div class="empty-state" id="emptyState">
     <h2>No project selected</h2>
     <p>Choose a project on the left, or add a new one, to get started.</p>
@@ -206,15 +215,6 @@ input[type="date"]::-webkit-calendar-picker-indicator{opacity:0.4;cursor:pointer
   <div class="page" id="page" style="display:none">
 
     <div class="readonly-banner" id="readonlyBanner">Viewing a past update — read only. Start a new update to make changes.</div>
-
-    <div class="header">
-      <img class="header-logo" src="/logo-300.jpg" alt="ONE70 Group">
-      <div class="header-center"><div class="doc-title">WEEKLY PROJECT UPDATE</div></div>
-      <div class="header-right">
-        <span class="upd-lbl">UPDATE #</span>
-        <span class="upd-value" id="updateNumDisplay">—</span>
-      </div>
-    </div>
 
     <div class="body">
 


### PR DESCRIPTION
## Summary

The ONE70 logo and "WEEKLY PROJECT UPDATE" title already existed, but lived inside `#page`, which stays `display:none` until a project is selected. Since the `wu_projects` table is now empty (per the earlier cleanup), the very first thing anyone sees on load is an unbranded "No project selected" box with nothing indicating what tool this is.

- Moved the header (logo + title + Update # display) out of `#page` to sit persistently above both the empty state and the form, inside `#mainArea`.
- Gave it its own rounded corners + bottom margin (previously it relied on `.page`'s `border-radius` + `overflow:hidden` to clip its top corners, which no longer applies now that it's not nested inside `.page`).
- No JS changes — same element IDs, same behavior once a project is selected.

## Testing

Verified via jsdom: header renders once at boot (before any project exists), remains a single instance (not duplicated) after selecting/creating a project, and the rest of the flow (empty state ↔ form toggling, Update # display) is unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PfHJJcPBPACD6iRCxbJAF2)_